### PR TITLE
Added Location when --show-dir is used with --tsv or --csv

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -183,8 +183,12 @@ class LegendaryCLI:
 
         if args.csv or args.tsv:
             writer = csv.writer(stdout, dialect='excel-tab' if args.tsv else 'excel')
-            writer.writerow(['App name', 'App title', 'Installed version', 'Available version', 'Update available'])
-            writer.writerows((game.app_name, game.title, game.version, versions[game.app_name],
+            writer.writerow(['App name', 'App title', 'Installed version', 'Available version', 'Update available'] + (['Location'] if args.include_dir else []))
+            if(args.include_dir): 
+                writer.writerows((game.app_name, game.title, game.version, versions[game.app_name],
+                              versions[game.app_name] != game.version,game.install_path) for game in games)
+            else:
+                writer.writerows((game.app_name, game.title, game.version, versions[game.app_name],
                               versions[game.app_name] != game.version) for game in games)
             return
 


### PR DESCRIPTION
In list-installed if --show-dir is used together with --csv or --tsv the install location is not shown.

I added an extra column "Location" with the install location to the output.