### PR TITLE
Make not enough disk space a warning

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -802,7 +802,7 @@ class LegendaryCore:
         if free < min_disk_space:
             free_mib = free / 1024 / 1024
             required_mib = min_disk_space / 1024 / 1024
-            results.failures.add(f'Not enough available disk space! {free_mib:.02f} MiB < {required_mib:.02f} MiB')
+            results.warnings.add(f'Not enough available disk space! {free_mib:.02f} MiB < {required_mib:.02f} MiB')
 
         return results
 


### PR DESCRIPTION
Hi,

First of all, a huge **Thank You** for this launcher. Switching to it, a much easier task than I imagined that only took me a few minutes (some 95% of which was just reviewing the various available commands), saved me almost 1500 megabytes of space and a lot of future headache that would've inevitably resulted if I, among other things, continued to manage my offline launch methods by hand. The launcher is a whole lot better than what I could've expected Epic Games itself to deliver - and that's while their current launcher is much _worse_ than that.

In an effort to make the launcher even better and more comfortable to use, I would like to direct Your attention to the error that occurs when it is found that the user doesn't have enough space on their drive to install a game. While it may seem that most of the time that error makes a lot of sense, there exist usecases wherein it is actually counterproductive - most commonly, when a game is only being updated, and therefore it is unlikely that the game's directory will actually grow by the size of the decompressed download, as well as when the user uses filesystem compression (a feature boasted, among others, by the NTFS filesystem), and has strong reasons to believe that the downloaded game will actually fit just fine.

I would therefore like to propose that the error be made into a warning, letting the user decide whether they want to continue. Alternatively, considering that there may be dummies who run out of space and then come here to yell, a console option could be created to override the error - my route of thought, while changing these seven characters total and writing this essay, was however that the launcher seems targeted at power users, and so that this obfuscation isn't necessary... Your call? :slightly_smiling_face:

Thank You for Your time.