### PR TITLE
Automatically use variables at sync-saves

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -362,8 +362,11 @@ class LegendaryCLI:
 
                 if '%' in save_path or '{' in save_path:
 
-                    logger.warning('Path contains unprocessed variables, Do you want to import them automatically')
+                    logger.warning('Path contains unprocessed variables')
                     if get_boolean_choice("Path contains variables, Do you want to import it automatically"):
+                        # Import automatically
+
+                        # find Wineprefix
                         if igame.app_name in self.core.lgd.config.sections() and "wine_prefix" in self.core.lgd.config[
                             igame.app_name]:
                             wine_prefix = self.core.lgd.config.get(igame.app_name, "wine_prefix")
@@ -375,27 +378,30 @@ class LegendaryCLI:
                         if len(save_path.split("%")) > 3:
                             logger.warning("Path has more than two Variables. It is not supported yet")
                             return
+                        # Environment variable
                         var = save_path.split("%")[1]
 
                         if var == "APPDATA":
-                            for i in open(os.path.join(wine_prefix, "user.reg")):
-                                if i.startswith("\"AppData\"="):
-                                    appdata_path = i.split("=")[1]
-                                    appdata_path = appdata_path.replace("\\\\", "/").replace("C:", "").replace("\"","").replace("\n", "")
-                                    break
+                            with open(os.path.join(wine_prefix, "user.reg")) as reg_file:
+                                for i in reg_file:
+                                    if i.startswith("\"AppData\"="):
+                                        appdata_path = i.split("=")[1]
+                                        appdata_path = appdata_path.replace("\\\\", "/").replace("C:", "").replace("\"",
+                                                                                                                   "").replace(
+                                            "\n", "")
+                                        break
 
-                            else:
-                                logger.error("No Appdata found in user.reg")
-                                return
+                                else:
+                                    logger.error("No Appdata found in user.reg")
+                                    return
                         else:
                             logger.warning(f"Variable {var} not supported")
                             return
 
                         save_path = save_path.split("%")[2]
-
                         save_path = wine_prefix + "/drive_c" + appdata_path + save_path
 
-                        # idk. this doesn't work
+                        # this doesn't work. Idk
                         # save_path = os.path.join(wine_prefix, "drive_c", appdata_path, save_path)
 
                         logger.info("Savepath: " + save_path)

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -386,8 +386,10 @@ class LegendaryCLI:
 
                             else:
                                 logger.error("No Appdata found in user.reg")
+                                return
                         else:
                             logger.warning(f"Variable {var} not supported")
+                            return
 
                         save_path = save_path.split("%")[2]
 

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -513,7 +513,6 @@ class LegendaryCLI:
                 if latest.build_version != igame.version:
                     logger.error('Game is out of date, please update or launch with update check skipping!')
                     exit(1)
-        print(args)
         params, cwd, env = self.core.get_launch_parameters(app_name=app_name, offline=args.offline,
                                                            extra_args=extra, user=args.user_name_override,
                                                            wine_bin=args.wine_bin, wine_pfx=args.wine_pfx,


### PR DESCRIPTION
On Linux you can now automatically use variables like %APPDATA% at sync-saves function. Legendary reads the user.reg file in the wineprefix defined in config.ini or in the default Wineprefix. 
It will not work, if the variable has another variable as content