### PR TITLE
Fix typo in CLI help (manfiests -> manifests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ optional arguments:
   --repair-and-update   Update game to the latest version when repairing
   --ignore-free-space   Do not abort if not enough free space is available
   --disable-delta-manifests
-                        Do not use delta manfiests when updating (may increase
+                        Do not use delta manifests when updating (may increase
                         download size)
 
 

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -1158,7 +1158,7 @@ def main():
     install_parser.add_argument('--ignore-free-space', dest='ignore_space', action='store_true',
                                 help='Do not abort if not enough free space is available')
     install_parser.add_argument('--disable-delta-manifests', dest='disable_delta', action='store_true',
-                                help='Do not use delta manfiests when updating (may increase download size)')
+                                help='Do not use delta manifests when updating (may increase download size)')
 
     uninstall_parser.add_argument('--keep-files', dest='keep_files', action='store_true',
                                   help='Keep files but remove game from Legendary database')


### PR DESCRIPTION
Fixes spelling in the CLI help