### PR TITLE
Refactor so that downloads can be initialised directly from core

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -24,8 +24,8 @@ from legendary.lfs.lgndry import LGDLFS
 from legendary.utils.lfs import clean_filename, delete_folder, delete_filelist, validate_files
 from legendary.models.downloading import AnalysisResult, ConditionCheckResult
 from legendary.models.egl import EGLManifest
-from legendary.models.exceptions import *
-from legendary.models.game import *
+from legendary.models.exceptions import InvalidCredentialsError
+from legendary.models.game import GameAsset, Game, InstalledGame, SaveGameFile, SaveGameStatus, VerifyResult
 from legendary.models.json_manifest import JSONManifest
 from legendary.models.manifest import Manifest, ManifestMeta
 from legendary.models.chunk import Chunk

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -14,14 +14,14 @@ from multiprocessing import Queue
 from random import choice as randchoice
 from requests import session
 from requests.exceptions import HTTPError
-from typing import List, Dict
+from typing import List, Dict, Callable
 from uuid import uuid4
 
 from legendary.api.egs import EPCAPI
 from legendary.downloader.manager import DLManager
 from legendary.lfs.egl import EPCLFS
 from legendary.lfs.lgndry import LGDLFS
-from legendary.utils.lfs import clean_filename, delete_folder, delete_filelist
+from legendary.utils.lfs import clean_filename, delete_folder, delete_filelist, validate_files
 from legendary.models.downloading import AnalysisResult, ConditionCheckResult
 from legendary.models.egl import EGLManifest
 from legendary.models.exceptions import *
@@ -33,6 +33,7 @@ from legendary.utils.game_workarounds import is_opt_enabled
 from legendary.utils.savegame_helper import SaveGameHelper
 from legendary.utils.manifests import combine_manifests
 from legendary.utils.wine_helpers import read_registry, get_shell_folders
+from legendary.utils.selective_dl import get_sdl_appname
 
 
 # ToDo: instead of true/false return values for success/failure actually raise an exception that the CLI/GUI
@@ -695,7 +696,60 @@ class LegendaryCore:
         else:
             return None
 
-    def prepare_download(self, game: Game, base_game: Game = None, base_path: str = '',
+    def verify_game(self, app_name: str, callback: Callable[[int, int], None]=print):
+        if not self.is_installed(app_name):
+            self.log.error(f'Game "{app_name}" is not installed')
+            return
+
+        self.log.info(f'Loading installed manifest for "{app_name}"')
+        igame = self.get_installed_game(app_name)
+        manifest_data, _ = self.get_installed_manifest(app_name)
+        manifest = self.load_manifest(manifest_data)
+
+        files = sorted(manifest.file_manifest_list.elements,
+                       key=lambda a: a.filename.lower())
+
+        # build list of hashes
+        file_list = [(f.filename, f.sha_hash.hex()) for f in files]
+        total = len(file_list)
+        num = 0
+        failed = []
+        missing = []
+
+        self.log.info(f'Verifying "{igame.title}" version "{manifest.meta.build_version}"')
+        repair_file = []
+        for result, path, result_hash in validate_files(igame.install_path, file_list):
+            if callback:
+                num += 1
+                callback(num, total)
+
+            if result == VerifyResult.HASH_MATCH:
+                repair_file.append(f'{result_hash}:{path}')
+                continue
+            elif result == VerifyResult.HASH_MISMATCH:
+                self.log.error(f'File does not match hash: "{path}"')
+                repair_file.append(f'{result_hash}:{path}')
+                failed.append(path)
+            elif result == VerifyResult.FILE_MISSING:
+                self.log.error(f'File is missing: "{path}"')
+                missing.append(path)
+            else:
+                self.log.error(f'Other failure (see log), treating file as missing: "{path}"')
+                missing.append(path)
+
+        # always write repair file, even if all match
+        if repair_file:
+            repair_filename = os.path.join(self.lgd.get_tmp_path(), f'{app_name}.repair')
+            with open(repair_filename, 'w') as f:
+                f.write('\n'.join(repair_file))
+            self.log.debug(f'Written repair file to "{repair_filename}"')
+
+        if not missing and not failed:
+            self.log.info('Verification finished successfully.')
+        else:
+            raise RuntimeError(f'Verification failed, {len(failed)} file(s) corrupted, {len(missing)} file(s) are missing.')
+
+    def prepare_download(self, app_name: str, base_path: str = '', no_install: bool = False,
                          status_q: Queue = None, max_shm: int = 0, max_workers: int = 0,
                          force: bool = False, disable_patching: bool = False,
                          game_folder: str = '', override_manifest: str = '',
@@ -704,8 +758,70 @@ class LegendaryCore:
                          file_exclude_filter: list = None, file_install_tag: list = None,
                          dl_optimizations: bool = False, dl_timeout: int = 10,
                          repair: bool = False, repair_use_latest: bool = False,
+                         ignore_space_req: bool = False,
                          disable_delta: bool = False, override_delta_manifest: str = '',
-                         egl_guid: str = '') -> (DLManager, AnalysisResult, ManifestMeta):
+                         egl_guid: str = '', reset_sdl: bool = False,
+                         sdl_prompt: Callable[[str, str], List[str]] = list) -> (DLManager, AnalysisResult, Game, InstalledGame, bool, str):
+        if self.is_installed(app_name):
+            igame = self.get_installed_game(app_name)
+            if igame.needs_verification and not repair:
+                self.log.info('Game needs to be verified before updating, switching to repair mode...')
+                repair = True
+
+        repair_file = ''
+        if repair:
+            repair = True
+            no_install = repair_use_latest is False
+            repair_file = os.path.join(self.lgd.get_tmp_path(), f'{app_name}.repair')
+
+        if not self.login():
+            raise RuntimeError('Login failed! Cannot continue with download process.')
+
+        if file_prefix_filter or file_exclude_filter or file_install_tag:
+            no_install = True
+
+        if platform_override:
+            no_install = True
+
+        game = self.get_game(app_name, update_meta=True)
+
+        if not game:
+            raise RuntimeError(f'Could not find "{app_name}" in list of available games,'
+                         f'did you type the name correctly?')
+
+        if game.is_dlc:
+            self.log.info('Install candidate is DLC')
+            app_name = game.metadata['mainGameItem']['releaseInfo'][0]['appId']
+            base_game = self.get_game(app_name)
+            # check if base_game is actually installed
+            if not self.is_installed(app_name):
+                # download mode doesn't care about whether or not something's installed
+                if not no_install:
+                    raise RuntimeError(f'Base game "{app_name}" is not installed!')
+        else:
+            base_game = None
+
+        if repair:
+            if not self.is_installed(game.app_name):
+                raise RuntimeError(f'Game "{game.app_title}" ({game.app_name}) is not installed!')
+
+            if not os.path.exists(repair_file):
+                self.log.info('Verifing game...')
+                self.verify_game(app_name)
+            else:
+                self.log.info(f'Using existing repair file: {repair_file}')
+
+        # Workaround for Cyberpunk 2077 preload
+        if not file_install_tag and not game.is_dlc and ((sdl_name := get_sdl_appname(game.app_name)) is not None):
+            config_tags = self.lgd.config.get(game.app_name, 'install_tags', fallback=None)
+            if not self.is_installed(game.app_name) or config_tags is None or reset_sdl:
+                file_install_tag = sdl_prompt(sdl_name, game.app_title)
+                if game.app_name not in self.lgd.config:
+                    self.lgd.config[game.app_name] = dict()
+                self.lgd.config.set(game.app_name, 'install_tags', ','.join(file_install_tag))
+            else:
+                file_install_tag = config_tags.split(',')
+
         # load old manifest
         old_manifest = None
 
@@ -857,7 +973,44 @@ class LegendaryCore:
                               is_dlc=base_game is not None, install_size=anlres.install_size,
                               egl_guid=egl_guid, install_tags=file_install_tag)
 
-        return dlm, anlres, igame
+        # game is either up to date or hasn't changed, so we have nothing to do
+        if not anlres.dl_size:
+            old_igame = self.get_installed_game(game.app_name)
+            self.log.info('Download size is 0, the game is either already up to date or has not changed. Exiting...')
+            if old_igame and repair and os.path.exists(repair_file):
+                if old_igame.needs_verification:
+                    old_igame.needs_verification = False
+                    self.install_game(old_igame)
+
+                self.log.debug('Removing repair file.')
+                os.remove(repair_file)
+
+            # check if install tags have changed, if they did; try deleting files that are no longer required.
+            if old_igame and old_igame.install_tags != igame.install_tags:
+                old_igame.install_tags = igame.install_tags
+                self.log.info('Deleting now untagged files.')
+                self.uninstall_tag(old_igame)
+                self.install_game(old_igame)
+
+            raise RuntimeError('Nothing to do.')
+
+        res = self.check_installation_conditions(analysis=anlres, install=igame, game=game,
+                                                      updating=self.is_installed(app_name),
+                                                      ignore_space_req=ignore_space_req)
+
+        if res.warnings or res.failures:
+            self.log.info('Installation requirements check returned the following results:')
+
+        if res.warnings:
+            for warn in sorted(res.warnings):
+                self.log.warning(warn)
+
+        if res.failures:
+            for msg in sorted(res.failures):
+                self.log.fatal(msg)
+            raise RuntimeError('Installation cannot proceed, exiting.')
+
+        return dlm, anlres, game, igame, repair, repair_file
 
     @staticmethod
     def check_installation_conditions(analysis: AnalysisResult,
@@ -924,6 +1077,23 @@ class LegendaryCore:
                                  f'this is currently unsupported and the game may not work.')
 
         return results
+
+    def clean_post_install(self, game: Game, igame: InstalledGame, repair: bool = False, repair_file: str = ''):
+        old_igame = self.get_installed_game(game.app_name)
+        if old_igame and repair and os.path.exists(repair_file):
+            if old_igame.needs_verification:
+                old_igame.needs_verification = False
+                self.install_game(old_igame)
+
+            self.log.debug('Removing repair file.')
+            os.remove(repair_file)
+
+        # check if install tags have changed, if they did; try deleting files that are no longer required.
+        if old_igame and old_igame.install_tags != igame.install_tags:
+            old_igame.install_tags = igame.install_tags
+            self.log.info('Deleting now untagged files.')
+            self.uninstall_tag(old_igame)
+            self.install_game(old_igame)
 
     def get_default_install_dir(self):
         return os.path.expanduser(self.lgd.config.get('Legendary', 'install_dir', fallback='~/legendary'))

--- a/legendary/downloader/manager.py
+++ b/legendary/downloader/manager.py
@@ -695,35 +695,30 @@ class DLManager(Process):
             total_avail = len(self.sms)
             total_used = (num_shared_memory_segments - total_avail) * (self.analysis.biggest_chunk / 1024 / 1024)
 
-            if runtime and processed_chunks:
-                rt_hours, runtime = int(runtime // 3600), runtime % 3600
-                rt_minutes, rt_seconds = int(runtime // 60), int(runtime % 60)
-
+            try:
                 average_speed = processed_chunks / runtime
                 estimate = (num_chunk_tasks - processed_chunks) / average_speed
-                hours, estimate = int(estimate // 3600), estimate % 3600
-                minutes, seconds = int(estimate // 60), int(estimate % 60)
-            else:
-                hours = minutes = seconds = 0
-                rt_hours = rt_minutes = rt_seconds = 0
+            except ZeroDivisionError:
+                average_speed = estimate = 0
 
-            self.log.info(f'= Progress: {perc:.02f}% ({processed_chunks}/{num_chunk_tasks}), '
-                          f'Running for {rt_hours:02d}:{rt_minutes:02d}:{rt_seconds:02d}, '
-                          f'ETA: {hours:02d}:{minutes:02d}:{seconds:02d}')
-            self.log.info(f' - Downloaded: {total_dl / 1024 / 1024:.02f} MiB, '
-                          f'Written: {total_write / 1024 / 1024:.02f} MiB')
-            self.log.info(f' - Cache usage: {total_used} MiB, active tasks: {self.active_tasks}')
-            self.log.info(f' + Download\t- {dl_speed / 1024 / 1024:.02f} MiB/s (raw) '
-                          f'/ {dl_unc_speed / 1024 / 1024:.02f} MiB/s (decompressed)')
-            self.log.info(f' + Disk\t- {w_speed / 1024 / 1024:.02f} MiB/s (write) / '
-                          f'{r_speed / 1024 / 1024:.02f} MiB/s (read)')
-
+            # TODO set current_filename argument of UIUpdate
             # send status update to back to instantiator (if queue exists)
             if self.status_queue:
                 try:
                     self.status_queue.put(UIUpdate(
-                        progress=perc, download_speed=dl_unc_speed, write_speed=w_speed, read_speed=r_speed,
-                        memory_usage=total_used * 1024 * 1024
+                        progress=perc,
+                        runtime=round(runtime),
+                        estimated_time_left=round(estimate),
+                        processed_chunks=processed_chunks,
+                        chunk_tasks=num_chunk_tasks,
+                        total_downloaded=total_dl,
+                        total_written=total_write,
+                        cache_usage=total_used,
+                        active_tasks=self.active_tasks,
+                        download_speed=dl_speed,
+                        download_decompressed_speed=dl_unc_speed,
+                        write_speed=w_speed,
+                        read_speed=r_speed,
                     ), timeout=1.0)
                 except Exception as e:
                     self.log.warning(f'Failed to send status update to queue: {e!r}')

--- a/legendary/models/downloading.py
+++ b/legendary/models/downloading.py
@@ -70,14 +70,23 @@ class UIUpdate:
     Status update object sent from the manager to the CLI/GUI to update status indicators
     """
 
-    def __init__(self, progress, download_speed, write_speed, read_speed,
-                 memory_usage, current_filename=''):
+    def __init__(self, progress, runtime, estimated_time_left, processed_chunks, chunk_tasks,
+                 total_downloaded, total_written, cache_usage, active_tasks, download_speed,
+                 download_decompressed_speed, write_speed, read_speed, current_filename=''):
         self.progress = progress
+        self.runtime = runtime
+        self.estimated_time_left = estimated_time_left
+        self.processed_chunks = processed_chunks
+        self.chunk_tasks = chunk_tasks
+        self.total_downloaded = total_downloaded
+        self.total_written = total_written
+        self.cache_usage = cache_usage
+        self.active_tasks = active_tasks
         self.download_speed = download_speed
+        self.download_decompressed_speed = download_decompressed_speed
         self.write_speed = write_speed
         self.read_speed = read_speed
         self.current_filename = current_filename
-        self.memory_usage = memory_usage
 
 
 class SharedMemorySegment:


### PR DESCRIPTION
A lot of functionality relating to starting a download e.g. checking if the base game is installed for a dlc; was implemented in the cli module, so it was not possible to directly start a download using the core module. I have fixed this by moving the relevant code to the core which will allow greater integration with the gui (https://github.com/Dummerle/Rare), which currently just runs the cli script for this.

I have also removed the status logging code from the download manager and moved it to cli using the status queue to send status updates.