### PR TITLE
Add Discord RPC

### DIFF
--- a/legendary/__init__.py
+++ b/legendary/__init__.py
@@ -1,4 +1,4 @@
 """Legendary!"""
 
-__version__ = '0.20.7'
+__version__ = '0.20.6'
 __codename__ = 'A Red Letter Day'

--- a/legendary/__init__.py
+++ b/legendary/__init__.py
@@ -1,4 +1,4 @@
 """Legendary!"""
 
-__version__ = '0.20.6'
+__version__ = '0.20.7'
 __codename__ = 'A Red Letter Day'

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -537,7 +537,7 @@ class LegendaryCLI:
 
             if exe_name is not None:
                 start = str(time.time()).split(".")[0]
-                RPC.update(large_image="legendarylogofull", large_text=app_title, state="via Legendary on " + platform.system(), details=app_title, start=start)
+                RPC.update(large_image="legendarylogo", large_text=app_title, state="via Legendary on " + platform.system(), details=app_title, start=start)
                 while True:
                     game_running = False
                     pids = psutil.pids()

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -514,6 +514,7 @@ class LegendaryCLI:
             if env:
                 logger.debug('Environment overrides:', env)
 
+            # Variable to tell the Discord RPC to disconnect
             manager = Manager()
             ns = manager.Namespace()
             ns.finish_rpc = False
@@ -523,8 +524,10 @@ class LegendaryCLI:
                 rpc.start()
 
             game_process = subprocess.Popen(params, cwd=cwd, env=env)
+            # Wait for game process to end
             game_process.wait()
 
+            # Tell Discord RPC to stop if it's running
             if not args.disable_rpc:
                 ns.finish_rpc = True
                 rpc.join()
@@ -532,18 +535,24 @@ class LegendaryCLI:
 
     def startRPC(self, app_name, ns):
         try:
+            # Discord app Client ID goes here
+            # A Discord app can be made at https://discord.com/developers/applications
             RPC = Presence('828711025863688192')
             RPC.connect()
 
+            # Get readable app title from app name
             app_title = self.core.get_game(app_name).app_title
 
+            # Start time of playing game
             start = str(time.time()).split(".")[0]
             RPC.update(large_image="legendarylogo", large_text=app_title, state="via Legendary on " + platform.system(), details=app_title, start=start)
 
+            # This will block forever until ns.finish_rpc is True so that the Discord RPC doesn't disconnect, but this is fine since this function is run in parallel as a separate process
             while not ns.finish_rpc:
                 time.sleep(1)
 
         except Exception as e:
+            # Catch all errors, like not being able to detect Discord, and display a warning
             print(f'Warning: {e} on Discord RPC start')
 
     def install_game(self, args):

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -42,7 +42,6 @@ class LegendaryCLI:
         self.core = LegendaryCore()
         self.logger = logging.getLogger('cli')
         self.logging_queue = None
-        self.finish_rpc = False
 
     def setup_threaded_logging(self):
         self.logging_queue = MPQueue(-1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests<3.0
+pypresence

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(
     install_requires=[
         'requests<3.0',
         'setuptools',
-        'wheel'
+        'wheel',
+        'pypresence',
+        'psutil'
     ],
     url='https://github.com/derrod/legendary',
     description='Free and open-source replacement for the Epic Games Launcher application',

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,7 @@ setup(
         'requests<3.0',
         'setuptools',
         'wheel',
-        'pypresence',
-        'psutil'
+        'pypresence'
     ],
     url='https://github.com/derrod/legendary',
     description='Free and open-source replacement for the Epic Games Launcher application',


### PR DESCRIPTION
This pull request adds Discord rich presence to Legendary. This does unfortunately change the behavior of Legendary. Instead of releasing the game process, the process now blocks because the Discord rich presence needs to continue running while the game is running. I attempted to just track the PID of the game but the original process seems to start a bunch of child processes and then end itself, which doesn't let me track it. If someone does merge this, you might want to make your own Discord app for Legendary on [https://discord.com/developers/applications](https://discord.com/developers/applications), and use that client ID instead of the one I currently have. I've made 3 different versions of the logo for the presence, and I'll attach them to the PR so you can choose which you like best. I've also attached an example of the rich presence. Tell me if you need any more info.

![image](https://user-images.githubusercontent.com/58576759/114253617-d8f51e00-9978-11eb-9ad4-6dba7b32bfb6.png)
Presence images: [https://imgur.com/a/4zDDs4R](https://imgur.com/a/4zDDs4R) (I'm currently using the middle one with the transparent background)
