### PR TITLE
Fix ValueError exception when calling shlex.split

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -466,7 +466,7 @@ class LegendaryCore:
         if wrapper or (wrapper := self.lgd.config.get(app_name, 'wrapper',
                                                       fallback=self.lgd.config.get('default', 'wrapper',
                                                                                    fallback=None))):
-            params.extend(shlex.split(wrapper))
+            params.extend(shlex.split(shlex.quote(wrapper)))
 
         if os.name != 'nt' and not disable_wine:
             if not wine_bin:
@@ -482,7 +482,7 @@ class LegendaryCore:
         params.append(game_exe)
 
         if install.launch_parameters:
-            params.extend(shlex.split(install.launch_parameters, posix=False))
+            params.extend(shlex.split(shlex.quote(install.launch_parameters), posix=False))
 
         params.extend([
             '-AUTH_LOGIN=unused',
@@ -516,7 +516,7 @@ class LegendaryCore:
             params.extend(extra_args)
 
         if config_args := self.lgd.config.get(app_name, 'start_params', fallback=None):
-            params.extend(shlex.split(config_args.strip()))
+            params.extend(shlex.split(shlex.quote(config_args.strip())))
 
         env = self.get_app_environment(app_name, wine_pfx=wine_pfx)
         return params, working_dir, env


### PR DESCRIPTION
When trying to run Shadow Tactics: Blades of the Shogun (using Heroic Games Launcher) I get an exception
```
Traceback (most recent call last):
  File "legendary/cli.py", line 1451, in <module>
  File "legendary/cli.py", line 1408, in main
  File "legendary/cli.py", line 493, in launch_game
  File "legendary/core.py", line 428, in get_launch_parameters
  File "shlex.py", line 311, in split
  File "shlex.py", line 300, in __next__
  File "shlex.py", line 109, in get_token
  File "shlex.py", line 191, in read_token
ValueError: No closing quotation
```
It is raised because quotation characters are not escaped with `shlex.quote` before being passed to `shlex.split`. Actually only the line with `install.launch_parameters` should be quoted for the game to work, but I quoted parameters in all three calls to `shlex.split`.

It is probably irrelevant, but when I tried to just launch the game with default wine and default prefix, I got a bunch of missing dll's. But if I specify the same wine and prefix that Heroic Games Launcher uses, the game starts without problems.