### PR TITLE
[lfs] Check if AppData/ProgramData paths exist

### DIFF
--- a/legendary/lfs/egl.py
+++ b/legendary/lfs/egl.py
@@ -34,11 +34,17 @@ class EPCLFS:
         if not self.appdata_path:
             raise ValueError('EGS AppData path is not set')
 
+        if not os.path.isdir(self.appdata_path):
+            raise ValueError('EGS AppData path does not exist')
+
         self.config.read(os.path.join(self.appdata_path, 'GameUserSettings.ini'), encoding='utf-8')
 
     def save_config(self):
         if not self.appdata_path:
             raise ValueError('EGS AppData path is not set')
+
+        if not os.path.isdir(self.appdata_path):
+            raise ValueError('EGS AppData path does not exist')
 
         with open(os.path.join(self.appdata_path, 'GameUserSettings.ini'), 'w', encoding='utf-8') as f:
             self.config.write(f, space_around_delimiters=False)
@@ -46,6 +52,10 @@ class EPCLFS:
     def read_manifests(self):
         if not self.programdata_path:
             raise ValueError('EGS ProgramData path is not set')
+
+        if not os.path.isdir(self.programdata_path):
+            # Not sure if we should `raise` here as well
+            return
 
         for f in os.listdir(self.programdata_path):
             if f.endswith('.item'):
@@ -70,6 +80,9 @@ class EPCLFS:
     def set_manifest(self, manifest: EGLManifest):
         if not self.programdata_path:
             raise ValueError('EGS ProgramData path is not set')
+
+        if not os.path.isdir(self.programdata_path):
+            raise ValueError('EGS ProgramData path does not exist')
 
         manifest_data = manifest.to_json()
         self.manifests[manifest.app_name] = manifest_data


### PR DESCRIPTION
When a user had EGL sync enabled and then deleted/uninstalled the EGL, we would still try to load manifests from the directories, which lead to just about every feature breaking & a somewhat inconclusive stacktrace.  
This PR avoids this issue by not reading manifests/configuration data when the folders don't exist.

Maybe we should also turn off egl sync if this happens?