### PR TITLE
Change all OSes to `-latest` in build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'windows-2019', 'macos-11']
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
       fail-fast: false
       max-parallel: 3
 


### PR DESCRIPTION
This will let Github automatically choose the latest stable version of the OSes and will remove the need to change it manually.