### PR TITLE
Add the --wait argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ optional arguments:
                         Override executable to launch (relative path)
   --origin              Launch Origin to activate or run the game.
   --json                Print launch information as JSON and exit
+  --wait                Wait for game to finish running
   --wine <wine binary>  Set WINE binary to use to launch the app
   --wine-prefix <wine pfx path>
                         Set WINE prefix to use

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ optional arguments:
                         Override executable to launch (relative path)
   --origin              Launch Origin to activate or run the game.
   --json                Print launch information as JSON and exit
-  --wait                Wait for game to finish running
+  --wait                Wait for the game to finish running
   --wine <wine binary>  Set WINE binary to use to launch the app
   --wine-prefix <wine pfx path>
                         Set WINE prefix to use

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -694,7 +694,10 @@ class LegendaryCLI:
             if params.environment:
                 logger.debug('Environment overrides: {}'.format(', '.join(
                     f'{k}={v}' for k, v in params.environment.items())))
-            subprocess.Popen(full_params, cwd=params.working_directory, env=full_env)
+            p = subprocess.Popen(full_params, cwd=params.working_directory, env=full_env)
+            if args.wait:
+                logger.debug('Waiting for program to finish...')
+                p.wait()
 
     def _launch_origin(self, args):
         game = self.core.get_game(app_name=args.app_name)
@@ -2727,6 +2730,7 @@ def main():
                                help='Launch Origin to activate or run the game.')
     launch_parser.add_argument('--json', dest='json', action='store_true',
                                help='Print launch information as JSON and exit')
+    launch_parser.add_argument('--wait', dest='wait', action='store_true', help='Wait for game to finish running')
 
     if os.name != 'nt':
         launch_parser.add_argument('--wine', dest='wine_bin', action='store', metavar='<wine binary>',

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -2730,7 +2730,7 @@ def main():
                                help='Launch Origin to activate or run the game.')
     launch_parser.add_argument('--json', dest='json', action='store_true',
                                help='Print launch information as JSON and exit')
-    launch_parser.add_argument('--wait', dest='wait', action='store_true', help='Wait for game to finish running')
+    launch_parser.add_argument('--wait', dest='wait', action='store_true', help='Wait for the game to finish running')
 
     if os.name != 'nt':
         launch_parser.add_argument('--wine', dest='wine_bin', action='store', metavar='<wine binary>',


### PR DESCRIPTION
**What is it?**
This set of commits adds the `--wait` argument to legendary. It simply makes legendary wait for the game to finish running before exiting.

**Why is it needed?**
There are automated processes out there that rely on tracking if the program is running (steam for example). Making legendary have `--wait` allows for the program to use legendary as a reference to if the game is still running. This is useful for setting up Epic games to run on the Steam Link.

