### PR TITLE
Update GH actions & specify Python version as dependency

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,23 +60,19 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Dependencies
-      run: sudo apt install
-        python3-all
-        python3-stdeb
-        dh-python
-        python3-requests
-        python3-setuptools
-        python3-wheel
-
-    - name: Webview Dependencies
-      run: sudo apt install 
-        python3-webview
-        python3-gi
-        python3-gi-cairo
-        gir1.2-gtk-3.0
+      run: |
+        sudo apt install ruby
+        sudo gem install fpm
 
     - name: Build
-      run: python3 setup.py --command-packages=stdeb.command bdist_deb
+      run: fpm
+        --input-type python
+        --output-type deb
+        --python-package-name-prefix python3
+        --deb-suggests python3-webview
+        --maintainer "Rodney <rodney@rodney.io>"
+        --category python
+        setup.py
 
     - name: Os version
       id: os_version
@@ -87,4 +83,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.os_version.outputs.version }}-deb-package
-        path: deb_dist/*.deb
+        path: ./*.deb

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -72,6 +72,7 @@ jobs:
         --deb-suggests python3-webview
         --maintainer "Rodney <rodney@rodney.io>"
         --category python
+        --depends "python3 >= 3.9"
         setup.py
 
     - name: Os version

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,9 +16,9 @@ jobs:
       max-parallel: 3
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
 
@@ -48,7 +48,7 @@ jobs:
       env:
         PYTHONOPTIMIZE: 1
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ runner.os }}-package
         path: legendary/dist/*
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Dependencies
       run: sudo apt install
@@ -84,7 +84,7 @@ jobs:
         source /etc/os-release
         echo ::set-output name=version::$NAME-$VERSION_ID
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.os_version.outputs.version }}-deb-package
         path: deb_dist/*.deb


### PR DESCRIPTION
The main goal of this PR was to get our required Python version (currently 3.9) into the Debian package's "Depends" field (currently, we just specified "any" version)
The tool we were using to generate the file, [`stdeb`](https://github.com/astraw/stdeb), mentions this option in their documentation ([here](https://github.com/astraw/stdeb#stdeb-distutils-command-options)), although it doesn't seem functional to me. Since `stdeb` seemed otherwise abandoned and relies on functionality that will soon be removed from Python (the `distutils` module), it seemed sensible to also find a new tool for the job.

After some searching, I've found [`fpm`](https://github.com/jordansissel/fpm) and ported our action to using it instead. This currently requires a few manual inputs (maintainers, required python version), but should in the future be able to be fetched from a `pyproject.toml` file (which is relatively easy to create). A PR for that feature is currently in the works ([here](https://github.com/jordansissel/fpm/pull/1982))

In the process of that, I've also updated some other action versions to get that Warning count at least *a little* lower