### PR TITLE
Use GB18030 for chinese locale to correctly map some utf8 symbols.

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -40,6 +40,8 @@ logger = logging.getLogger('cli')
 
 class LegendaryCLI:
     def __init__(self, override_config=None, api_timeout=None):
+        if sys.stdout.encoding == 'gbk' :
+            sys.stdout.reconfigure(encoding='gb18030')
         self.core = LegendaryCore(override_config, timeout=api_timeout)
         self.logger = logging.getLogger('cli')
         self.logging_queue = None

--- a/legendary/models/game.py
+++ b/legendary/models/game.py
@@ -56,6 +56,9 @@ class Game:
     base_urls: List[str] = field(default_factory=list)
     metadata: Dict = field(default_factory=dict)
 
+    def __post_init__(self):
+        self.app_name = self.app_name.removesuffix('\t')
+
     def app_version(self, platform='Windows'):
         if platform not in self.asset_infos:
             return None


### PR DESCRIPTION
Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2590
