### PR TITLE
Fix weirdness with \t in app names

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -509,6 +509,7 @@ class LegendaryCore:
         ignore = set(i.app_name for i in self.get_assets())
 
         for libitem in self.egs.get_library_items():
+            libitem['appName'] = libitem['appName'].strip()  # handle issues with \t etc.
             if libitem['namespace'] == 'ue' and skip_ue:
                 continue
             if libitem['appName'] in ignore:


### PR DESCRIPTION
As of me adding FO:NV to my library today, I am getting an OSError while trying to `set_game_meta` for a manifest with `{hex}\t.json`.
I am using Rare as a frontend, but I can confirm editing core.py in my lib folder works while the default fails with
```
Traceback (most recent call last):
  File "D:\a\Rare\Rare\rare\shared\workers\worker.py", line 41, in run
  File "D:\a\Rare\Rare\rare\shared\workers\fetch.py", line 43, in run_real
  File "C:\hostedtoolcache\windows\Python\3.11.3\x64\Lib\site-packages\legendary\core.py", line 521, in get_non_asset_library_items
  File "C:\hostedtoolcache\windows\Python\3.11.3\x64\Lib\site-packages\legendary\lfs\lgndry.py", line 232, in set_game_meta
OSError: [Errno 22] Invalid argument: 'C:\\Users\\Kyle/.config/legendary\\metadata\\562d4a2c1b3147b089a7c453e3ddbcbe\t.json'
```
I will note that this should be considered a hotfix until the underlying cause is found