### PR TITLE
Catch exceptions when writing metadata to file

### DIFF
--- a/legendary/lfs/lgndry.py
+++ b/legendary/lfs/lgndry.py
@@ -229,7 +229,11 @@ class LGDLFS:
         json_meta = meta.__dict__
         self._game_metadata[app_name] = json_meta
         meta_file = os.path.join(self.path, 'metadata', f'{app_name}.json')
-        json.dump(json_meta, open(meta_file, 'w'), indent=2, sort_keys=True)
+        try:
+            json.dump(json_meta, open(meta_file, 'w'), indent=2, sort_keys=True)
+        except OSError as e:
+            self.log.error(f'Unable to write metadata to file: "{meta_file}" ! '
+                           f'(Error: {repr(e)})')
 
     def delete_game_meta(self, app_name):
         if app_name not in self._game_metadata:


### PR DESCRIPTION
For some reason, we cannot trust the EGS API to sanitize app name values, and in this case it contains a tab at the end, making the filename generation throw a big exception, that bubbles to the top.

I thought about sanitizing this several ways, but just catching the excepting here is probably the least headache, since this is fairly rare, and allows the rest of all related operations to continue normally for other library titles.
Attached 562d4a2c1b3147b089a7c453e3ddbcbe.json as it game from EGS API.

![WindowsTerminal_iidYKLS1ra](https://github.com/derrod/legendary/assets/24567452/85a72957-0743-4962-bdc0-e42d5c171d71)
[legendary-console.txt](https://github.com/derrod/legendary/files/11581494/legendary-console.txt)
[562d4a2c1b3147b089a7c453e3ddbcbe.json.txt](https://github.com/derrod/legendary/files/11581484/562d4a2c1b3147b089a7c453e3ddbcbe.json.txt)

