### PR TITLE
Correctly check for SDL tags and write tags to config after successful verification

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -984,6 +984,10 @@ class LegendaryCLI:
                 self.core.uninstall_tag(old_igame)
                 self.core.install_game(old_igame)
 
+            if old_igame.install_tags:
+                self.core.lgd.config.set(game.app_name, 'install_tags', ','.join(old_igame.install_tags))
+                self.core.lgd.save_config()
+
             # check if the version changed, this can happen for DLC that gets a version bump with no actual file changes
             if old_igame and old_igame.version != igame.version:
                 old_igame.version = igame.version
@@ -1225,7 +1229,7 @@ class LegendaryCLI:
                        key=lambda a: a.filename.lower())
 
         # build list of hashes
-        if config_tags := self.core.lgd.config.get(args.app_name, 'install_tags', fallback=None):
+        if config_tags := self.core.lgd.config.get(args.app_name, 'install_tags', fallback=None) is not None:
             install_tags = set(i.strip() for i in config_tags.split(','))
             file_list = [
                 (f.filename, f.sha_hash.hex())


### PR DESCRIPTION
If a game has a `__required` SDL which is an empty string will fail verification because the check for building the list of hashes will fail, implying that the whole game including all the SDLs will be validated.

At the same time, if we are importing a game using a config file that doesn't specify the `install_tags` for such a game, the install tags won't be saved due to calling an early `exit(0)`.

These two issues combined can cause a verification, repair, verification loop. This commit addresses both of those issues.

Example game: Fallout 3

Related conversation on Discord:
https://discord.com/channels/695233346627698689/695234626582609940/1084939380713594924