### PR TITLE
[cli] Actually store user-provided prefix path

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -104,11 +104,11 @@ class LegendaryCLI:
 
                 if not egl_wine_pfx:
                     logger.info('Please enter the path to the Wine prefix that has EGL installed')
-                    wine_pfx = input('Path [empty input to quit]: ').strip()
-                    if not wine_pfx:
+                    egl_wine_pfx = input('Path [empty input to quit]: ').strip()
+                    if not egl_wine_pfx:
                         print('Empty input, quitting...')
                         exit(0)
-                    if not os.path.exists(wine_pfx) and os.path.isdir(wine_pfx):
+                    if not os.path.exists(egl_wine_pfx) and os.path.isdir(egl_wine_pfx):
                         print('Path is invalid (does not exist)!')
                         exit(1)
 


### PR DESCRIPTION
On non-Windows, `auth`'s `--import` flag prompts the user for a Wine prefix to import the login data from. The provided path is stored inside `wine_pfx` and... never used again. Because of that, `egl_wine_pfx` will always be `None` when reaching the below `try` block & the `os.path.join` in `read_registry` will throw an exception
I assume this was meant to assign to `egl_wine_pfx` directly