### PR TITLE
Introduce LEGENDARY_CONFIG_PATH

### DIFF
--- a/legendary/lfs/lgndry.py
+++ b/legendary/lfs/lgndry.py
@@ -26,7 +26,9 @@ class LGDLFS:
     def __init__(self, config_file=None):
         self.log = logging.getLogger('LGDLFS')
 
-        if config_path := os.environ.get('XDG_CONFIG_HOME'):
+        if config_path := os.environ.get('LEGENDARY_CONFIG_PATH'):
+            self.path = os.path.join(config_path, 'legendary')
+        elif config_path := os.environ.get('XDG_CONFIG_HOME'):
             self.path = os.path.join(config_path, 'legendary')
         else:
             self.path = os.path.expanduser('~/.config/legendary')

--- a/legendary/lfs/lgndry.py
+++ b/legendary/lfs/lgndry.py
@@ -27,7 +27,7 @@ class LGDLFS:
         self.log = logging.getLogger('LGDLFS')
 
         if config_path := os.environ.get('LEGENDARY_CONFIG_PATH'):
-            self.path = os.path.join(config_path, 'legendary')
+            self.path = config_path
         elif config_path := os.environ.get('XDG_CONFIG_HOME'):
             self.path = os.path.join(config_path, 'legendary')
         else:


### PR DESCRIPTION
This allows heroic games launcher to use a custom directory for its config while not messing with the config paths of other wrapper scripts which also read XDG_CONFIG_HOME

I don't write python code and defintely don't exactly know what a `:=` operator does, so pls correct this if it's wrong