### PR TITLE
[cli] Use start.exe when launching a URI

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -779,6 +779,8 @@ class LegendaryCLI:
                          f'wrapper in the configuration file or command line. See the README for details.')
             return
 
+        # You cannot launch a URI without start.exe
+        command.append('start')
         command.append(origin_uri)
         if args.dry_run:
             if cmd:


### PR DESCRIPTION
The Windows version should use start.exe as well instead of going through your web browser (wtf?)
Unfortunately, I can't test the Windows version, so that's just going to remain the same for now