### PR TITLE
fix: add required arg name for FileLock >=3.15.3

### DIFF
--- a/legendary/lfs/utils.py
+++ b/legendary/lfs/utils.py
@@ -159,10 +159,10 @@ def get_dir_size(path):
 
 
 class LockedJSONData(FileLock):
-    def __init__(self, file_path: str):
-        super().__init__(file_path + '.lock')
+    def __init__(self, lock_file: str):
+        super().__init__(lock_file + '.lock')
 
-        self._file_path = file_path
+        self._file_path = lock_file
         self._data = None
         self._initial_data = None
 


### PR DESCRIPTION
Updating filelock to >=3.15.3 completely breaks the app with the following error:
```
PS C:\Users\Kloon> legendary list
[cli] INFO: Logging in...
Exception ignored in: <function BaseFileLock.__del__ at 0x0000020F53924860>
Traceback (most recent call last):
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\filelock\_api.py", line 400, in __del__
    self.release(force=True)
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\filelock\_api.py", line 361, in release
    if self.is_locked:
       ^^^^^^^^^^^^^^
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\filelock\_api.py", line 267, in is_locked
    return self._context.lock_file_fd is not None
           ^^^^^^^^^^^^^
AttributeError: 'LockedJSONData' object has no attribute '_context'
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\Scripts\legendary.exe\__main__.py", line 7, in <module>
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\legendary\cli.py", line 3060, in main
    cli.list_games(args)
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\legendary\cli.py", line 191, in list_games
    if not self.core.login():
           ^^^^^^^^^^^^^^^^^
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\legendary\core.py", line 253, in login
    with self.lgd.userdata_lock as lock:
  File "C:\Program Files\Python311\Lib\contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\legendary\lfs\lgndry.py", line 152, in userdata_lock
    with LockedJSONData(os.path.join(self.path, 'user.json')) as lock:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Kloon\AppData\Roaming\Python\Python311\site-packages\filelock\_api.py", line 137, in __call__
    instance = super().__call__(**init_params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: LockedJSONData.__init__() got an unexpected keyword argument 'lock_file'
```
This PR renames the arg to match the required keyword name.