### PR TITLE
[lfs] crossover: allow overriding bottles path via CX_BOTTLE_PATH

### DIFF
--- a/legendary/lfs/crossover.py
+++ b/legendary/lfs/crossover.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 _logger = logging.getLogger('CXHelpers')
-
+bottles_dir = os.environ["CX_BOTTLE_PATH"] if "CX_BOTTLE_PATH" in os.environ else '~/Library/Application Support/CrossOver/Bottles'
 
 def mac_get_crossover_version(app_path):
     try:
@@ -37,19 +37,19 @@ def mac_find_crossover_apps():
 
 
 def mac_get_crossover_bottles():
-    bottles_path = os.path.expanduser('~/Library/Application Support/CrossOver/Bottles')
+    bottles_path = os.path.expanduser(bottles_dir)
     if not os.path.exists(bottles_path):
         return []
     return sorted(p for p in os.listdir(bottles_path) if mac_is_valid_bottle(p))
 
 
 def mac_is_valid_bottle(bottle_name):
-    bottles_path = os.path.expanduser('~/Library/Application Support/CrossOver/Bottles')
+    bottles_path = os.path.expanduser(bottles_dir)
     return os.path.exists(os.path.join(bottles_path, bottle_name, 'cxbottle.conf'))
 
 
 def mac_get_bottle_path(bottle_name):
-    bottles_path = os.path.expanduser('~/Library/Application Support/CrossOver/Bottles')
+    bottles_path = os.path.expanduser(bottles_dir)
     return os.path.join(bottles_path, bottle_name)
 
 


### PR DESCRIPTION
Allows overriding the default directory containing CrossOver bottles and used to launch games in bottles, which is also the same environment variable used by the wine executable from CrossOver once executed.

If desired, to allow this to be configurable via `~/.config/legendary/config.ini`, one would need to overwrite the environment variable the same way `CX_BOTTLE` is done in `core.py`/etc