### PR TITLE
Implement file cache

### DIFF
--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -170,6 +170,9 @@ class FileWorker(Process):
         last_filename = ''
         current_file = None
 
+        if not os.path.exists(self.cache_path):
+            os.makedirs(self.cache_path)
+
         while True:
             try:
                 try:
@@ -275,8 +278,6 @@ class FileWorker(Process):
                         current_file.write(self.shm.buf[shm_offset:shm_end])
                     elif j.cache_file:
                         with open(os.path.join(self.cache_path, j.cache_file), 'rb') as f:
-                            if j.chunk_offset:
-                                f.seek(j.chunk_offset)
                             current_file.write(f.read(j.chunk_size))
                     elif j.old_file:
                         with open(os.path.join(self.base_path, j.old_file), 'rb') as f:

--- a/legendary/models/downloading.py
+++ b/legendary/models/downloading.py
@@ -48,7 +48,9 @@ class ChunkTask:
     chunk_guid: int
     chunk_offset: int = 0
     chunk_size: int = 0
-    # Whether this chunk can be removed from memory/disk after having been written
+    # Chunk should be added to the disk cache
+    cache: bool = False
+    # Whether this chunk can be removed from disk after having been written
     cleanup: bool = False
     # Path to the file the chunk is read from (if not from memory)
     chunk_file: Optional[str] = None
@@ -64,6 +66,7 @@ class TaskFlags(Flag):
     RELEASE_MEMORY = auto()
     MAKE_EXECUTABLE = auto()
     SILENT = auto()
+    CLEAR_CACHE = auto()
 
 
 @dataclass


### PR DESCRIPTION
Write chunks to disk if they have to be cached instead of keeping in memory.

Better to remove blocking cache creation and move it out from manager, but now it is the only way to guarantee that cache file saved before we need it for another file writing task

Closes #17
