### PR TITLE
[utils/cli] Accept empty string as a falsey value in strtobool

### DIFF
--- a/legendary/utils/cli.py
+++ b/legendary/utils/cli.py
@@ -84,7 +84,7 @@ def strtobool(val):
     val = val.lower()
     if val in ('y', 'yes', 't', 'true', 'on', '1'):
         return 1
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    elif val in ('n', 'no', 'f', 'false', 'off', '0', ''):
         return 0
     else:
         raise ValueError("invalid truth value %r" % (val,))


### PR DESCRIPTION
Some UE asset manifests seem to have `"OwnershipToken": ""` instead of something `strtobool` could understand. When trying to import these through `egl-sync` an exception is being raised, which blocks importing other titles too.
```
loathingkernel@akasha Rare (develop) $ legendary egl-sync --import-only
[cli] INFO: Reading EGL game manifests...

Checking for importable games...
Traceback (most recent call last):
  File "/home/loathingkernel/Projects/raredevs/Rare/venv/bin/legendary", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/loathingkernel/Projects/raredevs/Rare/venv/lib/python3.13/site-packages/legendary/cli.py", line 3097, in main
    cli.egs_sync(args)
    ~~~~~~~~~~~~^^^^^^
  File "/home/loathingkernel/Projects/raredevs/Rare/venv/lib/python3.13/site-packages/legendary/cli.py", line 1512, in egs_sync
    importable = self.core.egl_get_importable()
  File "/home/loathingkernel/Projects/raredevs/Rare/venv/lib/python3.13/site-packages/legendary/core.py", line 1797, in egl_get_importable
    return [g for g in self.egl.get_manifests()
                       ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/loathingkernel/Projects/raredevs/Rare/venv/lib/python3.13/site-packages/legendary/lfs/egl.py", line 69, in get_manifests
    return [EGLManifest.from_json(m) for m in self.manifests.values()]
            ~~~~~~~~~~~~~~~~~~~~~^^^
  File "/home/loathingkernel/Projects/raredevs/Rare/venv/lib/python3.13/site-packages/legendary/models/egl.py", line 96, in from_json
    tmp.ownership_token = strtobool(json.pop('OwnershipToken', 'False'))
                          ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/loathingkernel/Projects/raredevs/Rare/venv/lib/python3.13/site-packages/legendary/utils/cli.py", line 90, in strtobool
    raise ValueError("invalid truth value %r" % (val,))
ValueError: invalid truth value ''
```

The other use of `strtobool` is in `LGDRY_NO_WINE` environment variable, which also causes an exception if set as `LGDRY_NO_WINE=`
```
loathingkernel@akasha ~ (master) $ LGDRY_NO_WINE= legendary launch Dodo
Traceback (most recent call last):
  File "/usr/bin/legendary", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/legendary/cli.py", line 2827, in main
    default=strtobool(os.environ.get('LGDRY_NO_WINE', 'False')),
            ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/legendary/utils/cli.py", line 90, in strtobool
    raise ValueError("invalid truth value %r" % (val,))
ValueError: invalid truth value ''
```

I believe in both cases it is fine to assume that an empty string input is false, hence adding it here.

Link to the relevant Rare issue: https://github.com/RareDevs/Rare/issues/563