### PR TITLE
Fix: Handle non-existent paths in case_insensitive_file_search

### DIFF
--- a/legendary/lfs/tests/test_wine_helpers.py
+++ b/legendary/lfs/tests/test_wine_helpers.py
@@ -1,0 +1,14 @@
+import unittest
+import os
+from unittest.mock import patch
+from legendary.lfs.wine_helpers import case_insensitive_file_search
+
+class TestWineHelpers(unittest.TestCase):
+    @patch('os.path.exists')
+    def test_case_insensitive_file_search_nonexistent_dir(self, mock_exists):
+        mock_exists.return_value = False
+        result = case_insensitive_file_search('/nonexistent/path/to/file.txt')
+        self.assertIsNone(result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/legendary/lfs/wine_helpers.py
+++ b/legendary/lfs/wine_helpers.py
@@ -25,6 +25,9 @@ def case_insensitive_file_search(path: str) -> str:
     Similar to case_insensitive_path_search: Finds a file case-insensitively
     Note that this *does* work on Windows, although it's rather pointless
     """
+    if not os.path.exists(os.path.dirname(path)):
+        return None
+
     path_parts = os.path.normpath(path).split(os.sep)
     # If path_parts[0] is empty, we're on Unix and thus start searching at /
     if not path_parts[0]:


### PR DESCRIPTION
The `case_insensitive_file_search` function in `legendary/lfs/wine_helpers.py` did not correctly handle cases where the parent directory of the provided path does not exist. This could lead to the function returning an invalid path, which could cause errors in other parts of the application.

This commit fixes the issue by adding a check to ensure the parent directory exists before proceeding with the file search. If the parent directory does not exist, the function will now return `None`.

A new test case has been added to verify this fix.