### PR TITLE
fix: prevent .netrc credentials from being injected into api calls

### DIFF
--- a/legendary/api/egs.py
+++ b/legendary/api/egs.py
@@ -37,11 +37,13 @@ class EPCAPI:
 
         self.session = requests.session()
         self.session.headers['User-Agent'] = self._user_agent
+        self.session.auth = lambda r: r
         # increase maximum pool size for multithreaded metadata requests
         self.session.mount('https://', requests.adapters.HTTPAdapter(pool_maxsize=16))
 
         self.unauth_session = requests.session()
         self.unauth_session.headers['User-Agent'] = self._user_agent
+        self.unauth_session.auth = lambda r: r
 
         self._oauth_basic = HTTPBasicAuth(self._user_basic, self._pw_basic)
 


### PR DESCRIPTION
A ~/.netrc file with a default entry causes requests to add an HTTP Basic
Auth header to all outgoing requests, including the library fetches, metadata, etc endpoints.
Epics's server interprets this header as invalid client credentials and
returns HTTP 400 invalid_client.

Setting session.auth to a no-op lambda takes precedence over netrc lookup
(requests only falls back to netrc when session.auth is unset) while
leaving proxy and CA bundle environment variable handling intact, unlike
`trust_env=False` which would disable those as well.
[Fixes issue ](https://github.com/Heroic-Games-Launcher/heroic-gogdl/issues/72)