### PR TITLE
fix: add 3rd param to setexchangecode callback

### DIFF
--- a/legendary/utils/webview_login.py
+++ b/legendary/utils/webview_login.py
@@ -83,6 +83,8 @@ class MockLauncher:
         webbrowser.open(url)
 
     def set_exchange_code(self, exchange_code, param):
+        if param:
+            logger.warning(f'Unknown parameter provided: {param}. Please report it on GitHub')
         self.inject_js = False
         logger.debug('Got exchange code (stage 1)!')
         # The default Windows webview retains cookies, GTK/Qt do not. Therefore we can

--- a/legendary/utils/webview_login.py
+++ b/legendary/utils/webview_login.py
@@ -82,7 +82,7 @@ class MockLauncher:
     def open_url_external(self, url):
         webbrowser.open(url)
 
-    def set_exchange_code(self, exchange_code):
+    def set_exchange_code(self, exchange_code, param):
         self.inject_js = False
         logger.debug('Got exchange code (stage 1)!')
         # The default Windows webview retains cookies, GTK/Qt do not. Therefore we can


### PR DESCRIPTION
I'm unsure what that param is, it could be an error indicator of some sorts, for now I'll just assume a happy path